### PR TITLE
[sd-excel] 이미지 삽입 버그 수정 및 행 삽입 성능 개선

### DIFF
--- a/packages/sd-excel/src/xmls/SdExcelXmlContentType.ts
+++ b/packages/sd-excel/src/xmls/SdExcelXmlContentType.ts
@@ -41,12 +41,14 @@ export class SdExcelXmlContentType implements ISdExcelXml {
   }
 
   add(partName: string, contentType: string): this {
-    this.data.Types.Override.push({
-      "$": {
-        "PartName": partName,
-        "ContentType": contentType,
-      },
-    });
+    if (!this.data.Types.Override.some((item: any) => item.$.PartName === partName)) {
+      this.data.Types.Override.push({
+        "$": {
+          "PartName": partName,
+          "ContentType": contentType,
+        },
+      });
+    }
 
     return this;
   }

--- a/packages/sd-excel/src/xmls/SdExcelXmlDrawing.ts
+++ b/packages/sd-excel/src/xmls/SdExcelXmlDrawing.ts
@@ -35,7 +35,7 @@ export class SdExcelXmlDrawing implements ISdExcelXml {
     this.data.wsDr.twoCellAnchor = this.data.wsDr.twoCellAnchor ?? [];
 
     const anchors = this.data.wsDr.twoCellAnchor;
-    const picId = anchors.length + 1;
+    const picId = (this.data.wsDr.oneCellAnchor?.length ?? 0) + anchors.length + 1;
     const name = `Picture ${picId}`;
 
     this.data.wsDr.twoCellAnchor.push({
@@ -82,6 +82,50 @@ export class SdExcelXmlDrawing implements ISdExcelXml {
           ],
         },
       ],
+      clientData: [{}],
+    });
+  }
+
+  addOneCellPicture(opts: {
+    r: number;
+    c: number;
+    width: number;
+    height: number;
+    left?: number;
+    top?: number;
+    blipRelId: string;
+  }): void {
+    this.data.wsDr.oneCellAnchor = this.data.wsDr.oneCellAnchor ?? [];
+    const anchors = this.data.wsDr.oneCellAnchor;
+    const picId = (this.data.wsDr.twoCellAnchor?.length ?? 0) + anchors.length + 1;
+    const name = `Picture ${picId}`;
+
+    anchors.push({
+      from: [{
+        col: [opts.c.toString()],
+        colOff: [((opts.left ?? 0) * 9525).toString()],
+        row: [opts.r.toString()],
+        rowOff: [((opts.top ?? 0) * 9525).toString()],
+      }],
+      ext: [{
+        $: {
+          cx: (opts.width * 9525).toString(),
+          cy: (opts.height * 9525).toString(),
+        },
+      }],
+      pic: [{
+        nvPicPr: [{
+          cNvPr: [{ $: { id: picId.toString(), name } }],
+          cNvPicPr: [{ "a:picLocks": [{ $: { noChangeAspect: "1" } }] }],
+        }],
+        blipFill: [{
+          "a:blip": [{ $: { "r:embed": opts.blipRelId } }],
+          "a:stretch": [{ "a:fillRect": [] }],
+        }],
+        spPr: [{
+          "a:prstGeom": [{ $: { prst: "rect" }, "a:avLst": [] }],
+        }],
+      }],
       clientData: [{}],
     });
   }


### PR DESCRIPTION
## Summary

- **addImageAsync 복수 이미지 삽입 시 파일 손상 버그 수정**: 매 호출마다 새 drawing 생성 → 기존 drawing 재사용 (`_ensureDrawingAsync` 헬퍼)
- **addDrawingAsync 신규 추가**: oneCellAnchor 방식의 고정 크기 이미지 삽입 (레거시 `drawing()` 마이그레이션)
- **insertCopyRowAsync O(n²) → O(n) 성능 개선**: `insertEmptyRow`로 행 번호만 shift 후 소스 1행만 clone
- **setMergeCells 병합 셀 스타일(border) 보존**: `deleteCell` → `clearCellValue`로 변경

## Test plan

- [ ] TypeScript 타입 체크 통과 확인
- [ ] 기존 image-insert.spec.ts 테스트 통과 확인
- [ ] addImageAsync — 이미지 2개 이상 추가 후 xlsx 정상 열림 확인
- [ ] addDrawingAsync — 고정 크기 이미지 삽입 후 정상 열림 확인
- [ ] insertCopyRowAsync — 행 삽입 후 셀/merge 정상 확인
- [ ] 실제 XLSX 다운로드 테스트

🤖 Generated with [Claude Code](https://claude.ai/claude-code)