### PR TITLE
[sd-excel] ISdExcelXmlDrawingData에 oneCellAnchor 타입 복원

### DIFF
--- a/packages/sd-excel/src/types.ts
+++ b/packages/sd-excel/src/types.ts
@@ -192,6 +192,31 @@ export interface ISdExcelXmlDrawingData {
       }[];
       clientData?: any[]; // clientData는 보통 빈 객체
     }[];
+    oneCellAnchor?: {
+      from?: {
+        col: string[];
+        colOff?: string[];
+        row: string[];
+        rowOff?: string[];
+      }[];
+      ext?: {
+        $: { cx: string; cy: string };
+      }[];
+      pic?: {
+        nvPicPr?: {
+          cNvPr?: { $: { id: string; name: string } }[];
+          cNvPicPr?: Array<{ "a:picLocks"?: Array<{ $: { noChangeAspect?: string } }> }>;
+        }[];
+        blipFill?: {
+          "a:blip"?: Array<{ $: { "r:embed": string } }>;
+          "a:stretch"?: Array<{ "a:fillRect": any[] }>;
+        }[];
+        spPr?: {
+          "a:prstGeom"?: Array<{ "$": { prst: string }; "a:avLst": any[] }>;
+        }[];
+      }[];
+      clientData?: any[];
+    }[];
   };
 }
 


### PR DESCRIPTION
## Summary

- PR #1에서 누락된 `oneCellAnchor` 타입 정의를 `ISdExcelXmlDrawingData`에 복원
- `addOneCellPicture()` 메서드가 이 타입에 의존하므로 필수
- OOXML 스펙상 `twoCellAnchor`(from+to)와 `oneCellAnchor`(from+ext)는 별도 XML 태그

## Test plan

- [ ] TypeScript 타입 체크 통과 확인
- [ ] 기존 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)